### PR TITLE
 Add multi-domain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Benefits:
 
 In your `docker-compose.yml`:
 
-```
+```yaml
 services:
   ...
   # add the certbot service
@@ -54,8 +54,8 @@ Configure your webserver to serve `/.well-known` from `/challenges/.well-known` 
 
 ### Sample config for Nginx:
 
-`nginx.conf`:
-```
+```nginx
+# nginx.conf
 
 http {
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ services:
     image: olivierdalang/certbot:latest
     environment:
       - EMAIL=admin@example.com
-      - DOMAIN=example.com
+      - DOMAINS=example.com,www.example.com
       - MODE=staging
       - HOOK=docker restart mystack_nginx_1
     volumes:
@@ -43,7 +43,7 @@ volumes:
   challenges:
 ```
 
-Set `EMAIL` and `DOMAIN` accordingly.
+Set `EMAIL` and `DOMAINS` accordingly. `DOMAINS` can be a single domain, or a list of comma-separated domains (Certbot will generate a certificate covering all the domains, but the self-signed certificate will only use the first one)
 
 Set `MODE` to `production` to get real certificates (but first: check that it works, as you may hit API limit quickly if anything goes wrong). You can also set it to `disabled` to skip completely letsencrypt (you'd only get the self-signed certificates, which can be enough for development). Defaults to `staging`.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ services:
     image: olivierdalang/certbot:latest
     environment:
       - EMAIL=admin@example.com
-      - DOMAIN=example.com
+      - DOMAIN=example.com,www.example.com
       - MODE=staging
       - HOOK=docker restart mystack_nginx_1
     volumes:
@@ -43,7 +43,7 @@ volumes:
   challenges:
 ```
 
-Set `EMAIL` and `DOMAIN` accordingly.
+Set `EMAIL` and `DOMAIN` accordingly. `DOMAIN` can be a single domain, or a list of comma-separated domains (Certbot will generate a certificate covering all the domains, but the self-signed certificate will only use the first one).
 
 Set `MODE` to `production` to get real certificates (but first: check that it works, as you may hit API limit quickly if anything goes wrong). You can also set it to `disabled` to skip completely letsencrypt (you'd only get the self-signed certificates, which can be enough for development). Defaults to `staging`.
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,9 +6,10 @@ echo "Running entrypoint at $(date '+%Y/%m/%d %H:%M:%S')..."
 # If no certs exist, we create self-signed certs, as nginx/other may refuse to start
 # without certificates files, preventing them from serving the challenges.
 if [ ! -f /etc/letsencrypt/live/default/privkey.pem ] ||  [ ! -f /etc/letsencrypt/live/default/cert.pem ]; then
-    echo "No letsencrypt certificates found. We need self-signed fallback certificates."
+    echo "No letsencrypt certificates found."
+    echo "Looking for self-signed fallback certificates."
     if [ ! -f /etc/letsencrypt/self-signed/privkey.pem ] ||  [ ! -f /etc/letsencrypt/self-signed/cert.pem ]; then
-        echo "No self-signed certificates found. We will create some"
+        echo "No self-signed certificates found. Generating..."
         mkdir -p /etc/letsencrypt/self-signed
         openssl req \
             -new \
@@ -19,17 +20,17 @@ if [ ! -f /etc/letsencrypt/live/default/privkey.pem ] ||  [ ! -f /etc/letsencryp
             -subj "/C=XX/ST=XXX/L=XXX/O=XXX/CN=${DOMAIN}" \
             -keyout /etc/letsencrypt/self-signed/privkey.pem \
             -out /etc/letsencrypt/self-signed/cert.pem
-        ln -fs ./self-signed/privkey.pem /etc/letsencrypt/privkey.pem 
-        ln -fs ./self-signed/cert.pem /etc/letsencrypt/cert.pem 
+        ln -fs ./self-signed/privkey.pem /etc/letsencrypt/privkey.pem
+        ln -fs ./self-signed/cert.pem /etc/letsencrypt/cert.pem
     else
-        echo "Self-signed certificates already exist."
+        echo "Existing self-signed certificates found."
     fi
 fi
 
 if [ "$MODE" = "disabled" ]; then
 
-    echo "YOU ARE IN DISABLED MODE. Set MODE=staging or MODE=production to get a letsencrypt certificate."
-    COMMAND="echo '*** certbot would run now if MODE was staging or production. ***'"
+    echo "***YOU ARE IN DISABLED MODE.***"
+    echo "Set MODE=staging or MODE=production to get a letsencrypt certificate."
 
 else
 
@@ -45,22 +46,24 @@ else
         COMMAND="$COMMAND --staging"
     fi
 
+    echo "We run the command once (initial check)..."
+    eval "$COMMAND"
+
+    echo "First sync was successful!"
 fi
-
-echo "We run the command once (initial check)..."
-eval "$COMMAND"
-
-echo "First sync was successful!"
 
 echo "We run the hook..."
 eval "$FULL_HOOK"
 
-echo "And prepare the following cronjob:"
-CRONJOB="0 * * * * $COMMAND"
-echo "$CRONJOB"
+if [ "$MODE" != "disabled" ]; then
 
-echo "Installing the cron job..."
-echo "$CRONJOB" > /etc/crontabs/root
+    echo "And prepare the following cronjob:"
+    CRONJOB="0 * * * * $COMMAND"
+    echo "$CRONJOB"
+
+    echo "Installing the cron job..."
+    echo "$CRONJOB" > /etc/crontabs/root
+fi
 
 echo "Starting..."
 exec "$@"


### PR DESCRIPTION
- multiple domains can be declared separated by commas
  `DOMAIN=example.com,www.example.com`
- only Certbot uses all domains
- self-signed certificate is always based on the first domain

In addition, a readme update.