### PR TITLE
Replace cert.pem by fullchain.pem

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Set `MODE` to `production` to get real certificates (but first: check that it wo
 Set `HOOK` to the command to be run after succesful renewal. This allows to reload/restart the webservers.
 The container has access to the main docker socket and can thus run the same docker commands as the host.
 
-Configure your webserver to serve `/.well-known` from `/challenges/.well-known` and to load the certificates from `/certs/cert.pem` and `/certs/privkey.pem`.
+Configure your webserver to serve `/.well-known` from `/challenges/.well-known` and to load the certificates from `/certs/fullchain.pem` and `/certs/privkey.pem`.
 
 ### Sample config for Nginx:
 
@@ -75,7 +75,7 @@ http {
     server {
         listen          443 ssl default_server;
 
-        ssl_certificate     /certs/cert.pem;
+        ssl_certificate     /certs/fullchain.pem;
         ssl_certificate_key /certs/privkey.pem;
 
         # Replace this section
@@ -94,7 +94,7 @@ uwsgi \
     # port 80 must be open for the challenge
     --http 0.0.0.0:80 \
     # this is our main socket with the certificates
-    --https 0.0.0.0:443,/certs/cert.pem,/certs/privkey.pem \
+    --https 0.0.0.0:443,/certs/fullchain.pem,/certs/privkey.pem \
     # serve the challenge
     --static-map /.well-known=/challenges/.well-known \
     # any request to /.well-known/* is served as is

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Set `MODE` to `production` to get real certificates (but first: check that it wo
 Set `HOOK` to the command to be run after succesful renewal. This allows to reload/restart the webservers.
 The container has access to the main docker socket and can thus run the same docker commands as the host.
 
-Configure your webserver to serve `/.well-known` from `/challenges/.well-known` and to load the certificates from `/certs/fullchain.pem` and `/certs/privkey.pem`.
+Configure your webserver to serve `/.well-known` from `/challenges/.well-known` and to load the certificates from `/certs/cert.pem` and `/certs/privkey.pem`.
 
 ### Sample config for Nginx:
 
@@ -75,7 +75,7 @@ http {
     server {
         listen          443 ssl default_server;
 
-        ssl_certificate     /certs/fullchain.pem;
+        ssl_certificate     /certs/cert.pem;
         ssl_certificate_key /certs/privkey.pem;
 
         # Replace this section
@@ -94,7 +94,7 @@ uwsgi \
     # port 80 must be open for the challenge
     --http 0.0.0.0:80 \
     # this is our main socket with the certificates
-    --https 0.0.0.0:443,/certs/fullchain.pem,/certs/privkey.pem \
+    --https 0.0.0.0:443,/certs/cert.pem,/certs/privkey.pem \
     # serve the challenge
     --static-map /.well-known=/challenges/.well-known \
     # any request to /.well-known/* is served as is

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,7 +22,7 @@ done
 
 # We create self-signed certs as fallback while we get actual certificates from letsencrypt,
 # as missing certs may prevent webservers from starting and thus serving the challenges.
-if [ ! -f /etc/letsencrypt/self-signed/privkey.pem ] ||  [ ! -f /etc/letsencrypt/self-signed/fullchain.pem ]; then
+if [ ! -f /etc/letsencrypt/self-signed/privkey.pem ] ||  [ ! -f /etc/letsencrypt/self-signed/cert.pem ]; then
     echo "No self-signed certificates found. Generating self-signed certificates..."
     mkdir -p /etc/letsencrypt/self-signed
     openssl req \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,7 +22,7 @@ done
 
 # We create self-signed certs as fallback while we get actual certificates from letsencrypt,
 # as missing certs may prevent webservers from starting and thus serving the challenges.
-if [ ! -f /etc/letsencrypt/self-signed/privkey.pem ] ||  [ ! -f /etc/letsencrypt/self-signed/cert.pem ]; then
+if [ ! -f /etc/letsencrypt/self-signed/privkey.pem ] ||  [ ! -f /etc/letsencrypt/self-signed/fullchain.pem ]; then
     echo "No self-signed certificates found. Generating self-signed certificates..."
     mkdir -p /etc/letsencrypt/self-signed
     openssl req \
@@ -33,16 +33,16 @@ if [ ! -f /etc/letsencrypt/self-signed/privkey.pem ] ||  [ ! -f /etc/letsencrypt
         -x509 \
         -subj "/C=XX/ST=XXX/L=XXX/O=XXX/CN=$DOMAIN_MAIN" \
         -keyout /etc/letsencrypt/self-signed/privkey.pem \
-        -out /etc/letsencrypt/self-signed/cert.pem
+        -out /etc/letsencrypt/self-signed/fullchain.pem
 else
     echo "Existing self-signed certificates found."
 fi
 
 # The pre_hook links to the self-signed certificates
-PRE_HOOK="ln -fs ./self-signed/privkey.pem /etc/letsencrypt/privkey.pem && ln -fs ./self-signed/cert.pem /etc/letsencrypt/cert.pem"
+PRE_HOOK="ln -fs ./self-signed/privkey.pem /etc/letsencrypt/privkey.pem && ln -fs ./self-signed/fullchain.pem /etc/letsencrypt/fullchain.pem"
 
 # The post_hook relinks the certificates (to replace self-signed ones) and then runs the provided HOOK
-DEPLOY_HOOK="ln -fs ./live/$MODE/privkey.pem /etc/letsencrypt/privkey.pem && ln -fs ./live/$MODE/cert.pem /etc/letsencrypt/cert.pem && $HOOK"
+DEPLOY_HOOK="ln -fs ./live/$MODE/privkey.pem /etc/letsencrypt/privkey.pem && ln -fs ./live/$MODE/fullchain.pem /etc/letsencrypt/fullchain.pem && $HOOK"
 
 if [ "$MODE" = "disabled" ]; then
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -33,16 +33,16 @@ if [ ! -f /etc/letsencrypt/self-signed/privkey.pem ] ||  [ ! -f /etc/letsencrypt
         -x509 \
         -subj "/C=XX/ST=XXX/L=XXX/O=XXX/CN=$DOMAIN_MAIN" \
         -keyout /etc/letsencrypt/self-signed/privkey.pem \
-        -out /etc/letsencrypt/self-signed/fullchain.pem
+        -out /etc/letsencrypt/self-signed/cert.pem
 else
     echo "Existing self-signed certificates found."
 fi
 
 # The pre_hook links to the self-signed certificates
-PRE_HOOK="ln -fs ./self-signed/privkey.pem /etc/letsencrypt/privkey.pem && ln -fs ./self-signed/fullchain.pem /etc/letsencrypt/fullchain.pem"
+PRE_HOOK="ln -fs ./self-signed/privkey.pem /etc/letsencrypt/privkey.pem && ln -fs ./self-signed/cert.pem /etc/letsencrypt/cert.pem"
 
 # The post_hook relinks the certificates (to replace self-signed ones) and then runs the provided HOOK
-DEPLOY_HOOK="ln -fs ./live/$MODE/privkey.pem /etc/letsencrypt/privkey.pem && ln -fs ./live/$MODE/fullchain.pem /etc/letsencrypt/fullchain.pem && $HOOK"
+DEPLOY_HOOK="ln -fs ./live/$MODE/privkey.pem /etc/letsencrypt/privkey.pem && ln -fs ./live/$MODE/fullchain.pem /etc/letsencrypt/cert.pem && $HOOK"
 
 if [ "$MODE" = "disabled" ]; then
 


### PR DESCRIPTION
To be accepted by all clients the final certificate must be served with its intermediate certificate:  
https://letsencrypt.org/certificates/  
http://nginx.org/en/docs/http/configuring_https_servers.html#chains